### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
   Rcpp (>= 0.12.0),
   RcppParallel (>= 5.0.1),
   Rdpack,
-  rstan (>= 2.18.1),
+  rstan (>= 2.26.0),
   rstantools (>= 2.2.0),
   stats
 LinkingTo: 
@@ -39,8 +39,8 @@ LinkingTo:
   Rcpp (>= 0.12.0),
   RcppEigen (>= 0.3.3.3.0),
   RcppParallel (>= 5.0.1),
-  rstan (>= 2.18.1),
-  StanHeaders (>= 2.18.0)
+  rstan (>= 2.26.0),
+  StanHeaders (>= 2.26.0)
 Suggests:
     testthat (>= 3.0.0),
     truncnorm (>= 1.0),

--- a/inst/stan/trunc_est.stan
+++ b/inst/stan/trunc_est.stan
@@ -42,7 +42,7 @@ data{
 	int<lower=0> n;
     real a;
 	real b;
-	real<lower=a,upper=b> y[n];
+	array[n] real<lower=a,upper=b> y;
 }
 parameters{
     real mu;


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
